### PR TITLE
use mod to improve performance

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -96,12 +96,12 @@ class JacobianPoint {
     const X1 = this.x;
     const Y1 = this.y;
     const Z1 = this.z;
-    const A = X1 ** 2n;
-    const B = Y1 ** 2n;
-    const C = B ** 2n;
-    const D = 2n * ((X1 + B) ** 2n - A - C);
-    const E = 3n * A;
-    const F = E ** 2n;
+    const A = mod(X1 ** 2n);
+    const B = mod(Y1 ** 2n);
+    const C = mod(B ** 2n);
+    const D = mod(2n * (mod(mod((X1 + B) ** 2n)) - A - C));
+    const E = mod(3n * A);
+    const F = mod(E ** 2n);
     const X3 = mod(F - 2n * D);
     const Y3 = mod(E * (D - X3) - 8n * C);
     const Z3 = mod(2n * Y1 * Z1);
@@ -125,12 +125,12 @@ class JacobianPoint {
     const Z2 = other.z;
     if (X2 === 0n || Y2 === 0n) return this;
     if (X1 === 0n || Y1 === 0n) return other;
-    const Z1Z1 = Z1 ** 2n;
-    const Z2Z2 = Z2 ** 2n;
-    const U1 = X1 * Z2Z2;
-    const U2 = X2 * Z1Z1;
-    const S1 = Y1 * Z2 * Z2Z2;
-    const S2 = Y2 * Z1 * Z1Z1;
+    const Z1Z1 = mod(Z1 ** 2n);
+    const Z2Z2 = mod(Z2 ** 2n);
+    const U1 = mod(X1 * Z2Z2);
+    const U2 = mod(X2 * Z1Z1);
+    const S1 = mod(Y1 * Z2 * Z2Z2);
+    const S2 = mod(mod(Y2 * Z1) * Z1Z1);
     const H = mod(U2 - U1);
     const r = mod(S2 - S1);
     // H = 0 meaning it's the same point.
@@ -143,7 +143,7 @@ class JacobianPoint {
     }
     const HH = mod(H ** 2n);
     const HHH = mod(H * HH);
-    const V = U1 * HH;
+    const V = mod(U1 * HH);
     const X3 = mod(r ** 2n - HHH - 2n * V);
     const Y3 = mod(r * (V - X3) - S1 * HHH);
     const Z3 = mod(Z1 * Z2 * H);


### PR DESCRIPTION
a little bit performance improved

bench before:
```
getPublicKey(utils.randomPrivateKey()) x 2,896 ops/sec @ 345μs/op
sign x 2,108 ops/sec @ 474μs/op
verify x 516 ops/sec @ 1ms/op
recoverPublicKey x 282 ops/sec @ 3ms/op
getSharedSecret aka ecdh x 320 ops/sec @ 3ms/op
getSharedSecret (precomputed) x 3,707 ops/sec @ 269μs/op
Point.fromHex (decompression) x 7,106 ops/sec @ 140μs/op
schnorr.sign x 227 ops/sec @ 4ms/op
schnorr.verify x 284 ops/sec @ 3ms/op
```

after:
```
getPublicKey(utils.randomPrivateKey()) x 3,158 ops/sec @ 316μs/op
sign x 2,158 ops/sec @ 463μs/op
verify x 509 ops/sec @ 1ms/op
recoverPublicKey x 281 ops/sec @ 3ms/op
getSharedSecret aka ecdh x 319 ops/sec @ 3ms/op
getSharedSecret (precomputed) x 3,710 ops/sec @ 269μs/op
Point.fromHex (decompression) x 7,276 ops/sec @ 137μs/op
schnorr.sign x 224 ops/sec @ 4ms/op
schnorr.verify x 284 ops/sec @ 3ms/op
```

about 9% of getPublicKey(high score 11%)
about 2.3% of sign(high score 5%)
about -%1.4 of verify (high score 1%)

I thank the root reason is small bigint multiply is faster than big one
