### PR TITLE
fix: export signature in mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,7 @@ import {
   utils,
   CURVE,
   Point,
+  Signature,
 } from './index.ts';
 import { hmac } from 'https://denopkg.com/chiefbiiko/hmac/mod.ts';
 
@@ -26,4 +27,4 @@ utils.hmacSha256 = async (key: Uint8Array, ...messages: Uint8Array[]): Promise<U
   return hmac('sha256', key, concatTypedArrays(...messages)) as Uint8Array;
 };
 
-export { getPublicKey, sign, verify, recoverPublicKey, getSharedSecret, utils, CURVE, Point };
+export { getPublicKey, sign, verify, recoverPublicKey, getSharedSecret, utils, CURVE, Point, Signature };


### PR DESCRIPTION
I have a library that uses the Signature class, but the mod does not export it:
```
error: Uncaught (in promise) TypeError: The requested module 'https://denopkg.com/paulmillr/noble-secp256k1/mod.ts' does not provide an export named 'Signature'
```