### PR TITLE
Add main/module fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "files": [
     "lib"
   ],
+  "main": "lib/index.js",
+  "module": "lib/esm/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc -d && tsc -p tsconfig.esm.json",


### PR DESCRIPTION
With package root imports relies on the main/module fields, see https://github.com/jacogr/test-noble-packaging (parcel/webpack bundles correctly, browserify needs the main field otherwise it doesn't find it)