### PR TITLE
feat: sign with extraData and verify strict or not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Generates deterministic ECDSA signature as per RFC6979.
 - `options?.recovered: boolean = false` - whether the recovered bit should be included in the result. In this case, the result would be an array of two items.
 - `options?.canonical: boolean = false` - whether a signature `s` should be no more than 1/2 prime order
 - `options?.der: boolean = true` - whether the returned signature should be in DER format. If `false`, it would be in Compact format (32-byte r + 32-byte s)
+- `options?.extraData: Uint8Array | string` - Added Entropy to the deterministic k generation.
 
 The function is asynchronous because we're utilizing built-in HMAC API to not rely on dependencies.
 
@@ -133,12 +134,13 @@ secp256k1.signSync(msgHash, privateKey)
 
 ##### `verify(signature, hash, publicKey)`
 ```typescript
-function verify(signature: Uint8Array, msgHash: Uint8Array, publicKey: Uint8Array): boolean
-function verify(signature: string, msgHash: string, publicKey: string): boolean
+function verify(signature: Uint8Array, msgHash: Uint8Array, publicKey: Uint8Array, strict = false): boolean
+function verify(signature: string, msgHash: string, publicKey: string, strict = false): boolean
 ```
 - `signature: Uint8Array | string | { r: bigint, s: bigint }` - object returned by the `sign` function
 - `msgHash: Uint8Array | string` - message hash that needs to be verified
 - `publicKey: Uint8Array | string | Point` - e.g. that was generated from `privateKey` by `getPublicKey`
+- `strict` - valid signatures with `s` value greater than 1/2 prime order are rejected.
 - Returns `boolean`: `true` if `signature == hash`; otherwise `false`
 
 ##### `recoverPublicKey(hash, signature, recovery)`

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ function verify(signature: string, msgHash: string, publicKey: string, strict = 
 - `signature: Uint8Array | string | { r: bigint, s: bigint }` - object returned by the `sign` function
 - `msgHash: Uint8Array | string` - message hash that needs to be verified
 - `publicKey: Uint8Array | string | Point` - e.g. that was generated from `privateKey` by `getPublicKey`
-- `strict` - valid signatures with `s` value greater than 1/2 prime order are rejected.
+- `strict` - valid signatures with `s` value greater than 1/2 prime order is rejected.
 - Returns `boolean`: `true` if `signature == hash`; otherwise `false`
 
 ##### `recoverPublicKey(hash, signature, recovery)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export declare class Signature {
     static fromDER(hex: Hex): Signature;
     static fromHex(hex: Hex): Signature;
     assertValidity(): void;
+    normalizeS(): Signature;
     toDERRawBytes(isCompressed?: boolean): Uint8Array;
     toDERHex(isCompressed?: boolean): string;
     toRawBytes(): Uint8Array;
@@ -65,11 +66,13 @@ declare type OptsRecov = {
     recovered: true;
     canonical?: true;
     der?: boolean;
+    extraData?: Hex;
 };
 declare type OptsNoRecov = {
     recovered?: false;
     canonical?: true;
     der?: boolean;
+    extraData?: Hex;
 };
 declare function sign(msgHash: U8A, privKey: PrivKey, opts: OptsRecov): Promise<[U8A, number]>;
 declare function sign(msgHash: string, privKey: PrivKey, opts: OptsRecov): Promise<[string, number]>;
@@ -82,7 +85,7 @@ declare function signSync(msgHash: U8A, privKey: PrivKey, opts?: OptsNoRecov): U
 declare function signSync(msgHash: string, privKey: PrivKey, opts?: OptsNoRecov): string;
 declare function signSync(msgHash: string, privKey: PrivKey, opts?: OptsNoRecov): string;
 export { sign, signSync };
-export declare function verify(signature: Sig, msgHash: Hex, publicKey: PubKey): boolean;
+export declare function verify(signature: Sig, msgHash: Hex, publicKey: PubKey, strict?: boolean): boolean;
 declare class SchnorrSignature {
     readonly r: bigint;
     readonly s: bigint;

--- a/index.ts
+++ b/index.ts
@@ -835,6 +835,7 @@ async function getQRSrfc6979(msgHash: Hex, privateKey: PrivKey, extraData?: Hex)
   if (extraData) {
     // K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1) || k')
     const e = pad32b(typeof extraData === 'string' ? hexToNumber(extraData) : bytesToNumber(extraData));
+    if (e.length !== 32) throw new Error('secp256k1: Expected 32 bytes of extra data')
     key = concatBytes(key, e);
   }
   // Steps D, E, F, G
@@ -864,6 +865,7 @@ function getQRSrfc6979Sync(msgHash: Hex, privateKey: PrivKey, extraData?: Hex): 
   if (extraData) {
     // K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1) || k')
     const e = pad32b(typeof extraData === 'string' ? hexToNumber(extraData) : bytesToNumber(extraData));
+    if (e.length !== 32) throw new Error('secp256k1: Expected 32 bytes of extra data')
     key = concatBytes(key, e);
   }
   // Steps D, E, F, G

--- a/index.ts
+++ b/index.ts
@@ -897,7 +897,7 @@ function getQRSrfc6979Sync(msgHash: Hex, privateKey: PrivKey, extraData?: Hex): 
 // `30${length}02${rLen}${rHex}02${sLen}${sHex}`
 function isDEREncoding(hex: string | Uint8Array): boolean {
   const str = hex instanceof Uint8Array ? bytesToHex(hex) : hex;
-  const length = parseByte(str.slice(2, 4));
+  const length = parseDERByte(str.slice(2, 4));
   return str.slice(0, 2) === '30' && length === str.length - 4 && str.slice(4, 6) === '02';
 }
 

--- a/test/vectors/ecdsa.json
+++ b/test/vectors/ecdsa.json
@@ -10301,6 +10301,13 @@
         "Q": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
         "m": "0000000000000000000000000000000000000000000000000000000000000003",
         "signature": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+      },
+      {
+        "description": "Fails verification if strict set to truthy value with high s value",
+        "strict": true,
+        "Q": "034cd032cdc72820498aeb0fdd25712aa4f6d263997cf7df140b8c42d44626b08c",
+        "m": "df8e1382d17bdac18f3c854815071226385803e85f06114129ebbcfcef991278",
+        "signature": "ec8cd8d7dcda4ff770c2858bdd93dd64806e218b11bb1971a4a09b065760b040c1095cf554dab161b2b2c46386fab2c81e57035be714b760ef507981f8f70073"
       }
     ]
   },


### PR DESCRIPTION
## Summary

1. add  `normalizeS` function to `Signature` to normalizes a signature to a "low S" form. 
2. add `strict` parameter to `verify`. If it is true, `signature.s` value greater than 1/2 prime order is rejected.
3. add `opts.extraData` option to `sign` as Added Entropy to the deterministic `k` generation.

## Thanks

Thanks for creating this awesome package!

This is my first contribution, please feel free to critique, and thanks for your code review 😄 .