### PR TITLE
fix: hash value in rfc6979 process should be modulo CURVE.n

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -809,7 +809,8 @@ type U8A = Uint8Array;
 // Steps A, B and C of RFC6979.
 function _abc6979(msgHash: Hex, privateKey: bigint, extraEntropy?: Hex) {
   if (msgHash == null) throw new Error(`sign: expected valid msgHash, not "${msgHash}"`);
-  const num = typeof msgHash === 'string' ? hexToNumber(msgHash) : bytesToNumber(msgHash);
+  let num = typeof msgHash === 'string' ? hexToNumber(msgHash) : bytesToNumber(msgHash);
+  num %= CURVE.n;
   // Step A is ignored, since we already provide hash instead of msg
   const h1 = pad32b(num);
   const h1n = bytesToNumber(h1);

--- a/index.ts
+++ b/index.ts
@@ -810,7 +810,7 @@ type U8A = Uint8Array;
 function _abc6979(msgHash: Hex, privateKey: bigint, extraEntropy?: Hex) {
   if (msgHash == null) throw new Error(`sign: expected valid msgHash, not "${msgHash}"`);
   let num = typeof msgHash === 'string' ? hexToNumber(msgHash) : bytesToNumber(msgHash);
-  num %= CURVE.n;
+  num = mod(num, CURVE.n);
   // Step A is ignored, since we already provide hash instead of msg
   const h1 = pad32b(num);
   const h1n = bytesToNumber(h1);

--- a/test/vectors/ecdsa.json
+++ b/test/vectors/ecdsa.json
@@ -94,7 +94,7 @@
       "description": "Strange hash",
       "d": "0000000000000000000000000000000000000000000000000000000000000001",
       "m": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "signature": "3f8fe493cf305a7f02b2d2c060ba66a8f7bd13a7a64d5200c0655ad069bd85b51cf94236c3857e33a1023a5216cbc81b1dc3adcc1c71f4212df1997ffdfb140a"
+      "signature": "7cb38cc5712e9e11a767615f6080dbc111c9cdd613eb98999fd92a86bafd45407923ca1f4d03471d2866f776ef8a6d3cac099b427331aeb245aa9dafeddcf115"
     },
     {
       "description": "Stange hash",
@@ -106,7 +106,13 @@
       "description": "Strange hash",
       "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
       "m": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "signature": "2d0b04a7560652f419e2542ea7d27f2c4afb0e111bb409cfe9f34b7ff7d3315850118e90fcfe28abd0635a2e90f00db72bdbfcedbf56dad4049de85798031b38"
+      "signature": "a7f83b5963eaf5332c633327cc967be8f4166d3f1e0b77f9761d8f4e42211e9a58aae31be1eb1e496923bbe8ca5e843cfb89f4d986d61d4edfd7d6fc3c9cf62c"
+    },
+    {
+      "description": "Strange hash",
+      "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+      "m": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+      "signature": "919026f3e239ea52cf530eb6d345dc2b56ef0928f1e9ad20d8f360284dc6504814395e7137e2204f15b69239010f3c34fbb3c858a29b0d106b1fa65bc0047263"
     },
     {
       "d": "2bdbaeb8139ae47b603c684269f765a088397adbe65c017dfc6d19819b44041d",


### PR DESCRIPTION
## Summary

Fixes a bug which would have resulted in incorrect values of `k` produced by the RFC6979 nonce-generation code, when signing any hash value greater than or equal to `CURVE.n`. This would not affect the validity of signatures, but was resulting in mismatching signatures compared to other secp256k1 implementations. It's doubtful that this would result in skewing of `k` values in any measurable amount relevant to security, since it only affects hash values `>= CURVE.n`, which would be rare.

I only noticed it because I was using your very awesome test vectors for my own purposes and discovered a mismatch in two of the 'strange hash' test-vectors. 

### Details

[RFC6979 Section 3.2 Step D](https://datatracker.ietf.org/doc/html/rfc6979#section-3.2) specifies the first HMAC pass to set `K` should be:
```
K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1))
```

[RFC6979 specifies that the `bits2octets` function should ensure the result is modulo the order of the finite field (`CURVE.n`)](https://datatracker.ietf.org/doc/html/rfc6979#section-2.3.4)

The code in this library wasn't properly implementing the `bits2octets` function, instead it was simply converting the hash into a number, then converting it back to a padded 32-length byte array _without_ the modulo operation. This unprocessed byte array was concatenated into the HMAC message content. So what we were really doing was:

```
K = HMAC_K(V || 0x00 || int2octets(x) || h1)
```

This was previously unnoticed because this would only have any effect on hash values greater than or equal to the order of the finite field, which for large order curves is extremely rare. Finding a hash preimage which satisfies this condition would be like winning a really shitty lottery.

However, if it _does_ happen, it would result in the RFC6979 code producing incorrect values for `k` compared to other compliant implementations, thus resulting in different (but valid) signatures. 

## Checking my Work

- [x] Tests pass
- [x] Added one extra test to cover case where hash is exactly equal to `CURVE.n`
- [x] Ran the two broken test cases and the one new case with other secp256k1 implementations, such as [`btcec`](https://github.com/btcsuite/btcd/tree/master/btcec) to confirm signatures match
