### PR TITLE
Add convertPublicKey function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1007,6 +1007,16 @@ export function getPublicKey(privateKey: PrivKey, isCompressed = false): Uint8Ar
 }
 
 /**
+ * Converts public key to full or compact public key.
+ * @param publicKey public key
+ * @param isCompressed whether to return full (65-byte), or compact (33-byte) key
+ * @returns short/full public key
+ */
+export function convertPublicKey(publicKey: PubKey, isCompressed = false): Uint8Array {
+  return normalizePublicKey(publicKey).toRawBytes(isCompressed);
+}
+
+/**
  * Recovers public key from signature and recovery bit.
  * @param msgHash message hash
  * @param signature DER or compact sig


### PR DESCRIPTION
Hi, I'm looking into using @noble-hashes, ethereum-cryptography, etc in [lodestar](https://github.com/chainsafe/lodestar) where appropriate.
We currently use [bcrypto](https://github.com/bcoin-org/bcrypto) for secp256k1, and they include a function to convert between compressed and uncompressed public keys.
This is used by us here: https://github.com/ChainSafe/discv5/blob/master/src/enr/v4.ts#L27-L29

This function would be useful for us and may make this library more feature-complete for folks looking for a lightweight alternative to bcrypto.