### PR TITLE
Add BPJS8 EC multiplication

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --print-width 100 --single-quote --write index.ts",
     "test": "jest",
     "coverage": "jest --coverage",
-    "bench": "node test/benchmark.js"
+    "bench": "node test/benchmark.js",
+    "check": "node test/check.js"
   },
   "author": "Paul Miller (https://paulmillr.com)",
   "homepage": "https://paulmillr.com/noble/",

--- a/test/check.js
+++ b/test/check.js
@@ -1,0 +1,67 @@
+const { run, mark, logMem } = require('micro-bmark');
+const secp = require('..');
+
+// run([4, 8, 16], async (windowSize) => {
+run(async (windowSize) => {
+  const samples = 1000;
+  //console.log(`-------\nBenchmarking window=${windowSize} samples=${samples}...`);
+  await mark(() => {
+    secp.utils.precompute(windowSize);
+  });
+
+  logMem();
+  console.log();
+
+  // await mark('getPublicKey 1 bit', samples * 10, () => {
+  //   secp.getPublicKey('0000000000000000000000000000000000000000000000000000000000000003');
+  // });
+
+  // await mark('getPublicKey 256 bit', samples * 10, () => {
+  //   secp.getPublicKey('7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcfcb');
+  // });
+  const privateKeys = new Array(2500).fill(0).map(() => secp.utils.randomPrivateKey());
+  const publicKeys = new Array(2500);
+  let i = 0;
+  await mark('getPublicKey(utils.randomPrivateKey())', 2500, () => {
+    publicKeys[i] = secp.getPublicKey(privateKeys[i++]);
+  });
+
+  const tweaks = privateKeys.map((pk) => BigInt(`0x${secp.utils.bytesToHex(pk)}`));
+
+  const total = 100 * 11;
+  let nRight = 0;
+  for (i = 0; i < 100; i++) {
+    const bpsjP = new secp.BPSJ8(secp.Point.BASE).multiply(tweaks[i]).toHex(true);
+    const checkP = secp.Point.BASE.multiply(tweaks[i]).toHex(true);
+    if (bpsjP === checkP) {
+      nRight++;
+    }
+    for (let j = 0; j < 10; j++) {
+      const P = secp.Point.fromHex(publicKeys[j]);
+      const bpsjP = new secp.BPSJ8(P).multiply(tweaks[i]).toHex(true);
+      const checkP = P.multiply(tweaks[i]).toHex(true);
+      if (bpsjP === checkP) {
+        nRight++;
+      }
+    }
+  }
+  console.log({nRight, total, percent: nRight/total*100});
+
+  for (let j = 0; j < 2; j++) {
+    i = j * 1000;
+    await mark('BPSJ8', 1000, () => {
+      new secp.BPSJ8(secp.Point.BASE).multiply(tweaks[i++]);
+    });
+    i = j * 1000;
+    await mark('window', 1000, () => {
+      secp.Point.BASE.multiply(tweaks[i++]);
+    });
+    i = j * 1000;
+    await mark('multiplyUnsafe', 1000, () => {
+      secp.Point.BASE.multiplyUnsafe(tweaks[i++]);
+    });
+  }
+
+  console.log();
+  logMem();
+});


### PR DESCRIPTION
Like my io-speedups PR, I am absolutely not attached to this code. My exploration of potential performance improvements was triggered by my work on MuSig2* signing, which currently gets ~140 ops/sec on my machine vs. 280 for schnorr, and 2000 for ECDSA when using noble-secp256k1. The result, so far, has been utter failure to improve my target metric. However, if this implementation is swapped in for `Point.multiply` when `_WINDOW_SIZE` is not set, ECDH is > 80% faster (453 vs 247 ops/sec on my machine).

Given the results below, an argument could also be made for dropping `multiplyUnsafe` in favor of this algorithm, since the slowdown is small, and it removes a potential footgun. I did some investigation of potential ways to close the gap to `multiplyUnsafe` and was able to bring it down to ~5% by replacing `mod` with `%` when the value is known to be positive, but the same optimization could be used to speedup `multiplyUnsafe`.

----

This is an algorithm for EC multiplication that emulates the Montgomery
Ladder double-and-add, but in a constant time way. An early version of
this algorithm was published in 2017, and the version implemented here
was published in 2020. The result is constant time multiply that is 85%
faster than wNAF, <10% slower than endomorphic Montgommery Ladder and
~20% faster than w/o endomorphism.

```
multiply (BPSJ8) x 433 ops/sec @ 2ms/op
multiply (precomputed) x 2,997 ops/sec @ 333μs/op
multiply (not precomputed) x 232 ops/sec @ 4ms/op
multiplyUnsafe x 465 ops/sec @ 2ms/op
multiplyUnsafe (no endomorphism) x 356 ops/sec @ 2ms/op
```