### PR TITLE
refactor: simplify double-2009-l expression for D

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ const _0n = BigInt(0);
 const _1n = BigInt(1);
 const _2n = BigInt(2);
 const _3n = BigInt(3);
+const _4n = BigInt(4);
 const _8n = BigInt(8);
 
 // Curve fomula is y² = x³ + ax + b

--- a/index.ts
+++ b/index.ts
@@ -130,7 +130,7 @@ class JacobianPoint {
     const A = mod(X1 ** _2n);
     const B = mod(Y1 ** _2n);
     const C = mod(B ** _2n);
-    const D = mod(_2n * (mod((X1 + B) ** _2n) - A - C));
+    const D = mod(_4n * X1 * B); // simplification of D = 2 * ((X1+B)² - A - C)
     const E = mod(_3n * A);
     const F = mod(E ** _2n);
     const X3 = mod(F - _2n * D);


### PR DESCRIPTION
Ported from [kklash/ekliptic#6](https://github.com/kklash/ekliptic/pull/6/files#diff-f7c66fb55c20add4eb039308d997fbf85155b7ac10f854ba06c09e844ae33ca1R30-R44)

in the dbl-2009-l jacobian point doubling formula, the expression for `D` can be simplified.

While experimenting with performance optimizations, I discovered that when I removed the `mod(D)` call, the formula still worked and all tests still passed. This meant the expression for `D` is always positive (if it ever became negative, the lack of `mod()` would have broken the formula when `D` is used later in multiplicative operations)

After expanding the terms to investigate, i noticed an opportunity to simplify, removing several subtraction and multiplication operations.

The official dbl-2009-l formula specifies:
```py
d = 2 * ((x1+b)² - a - c)
```

But it can be simplified, because:
```py
a = x1², c = b²
d = 2 * ((x1+b)² - a - c)
  = 2 * ((x1+b)² - x1² - b²)
  = 2 * ((x1+b)(x1+b) - x1² - b²)
  = 2 * (x1² + 2(x1*b) + b² - x1² - b²)
  = 2 * 2(x1*b)
```

So actually:
```py
d = 4 * x1 * b
``` 

Much easier on the eyes. 

- [x] Tests pass
- [x] Benchmarks run at the same speed on my machine


## Performance

This doesn't seem to have an observable impact for performance. Benchmarks churn out roughly the same speeds in both JS and Golang regardless of whether I use the simplified expression or the official one. 

Pruning unneeded `mod` calls would offer a more promising path to improve performance,  by porting the other changes from [`kklash/ekliptic#6`](https://github.com/kklash/ekliptic/pull/6), but I'm not yet sure if that's safe. What's your opinion @paulmillr ?

## Other impls

Should this get ported to other implementations? Looks like `python-ecdsa` has [a similar opportunity for simplification](https://github.com/tlsfuzzer/python-ecdsa/blob/3b49fbe1773052f2916b0fa22a363b14cb6e67bc/src/ecdsa/ellipticcurve.py#L767), and [so does `dcrd/dcrec`](https://github.com/decred/dcrd/blob/7d59dd3b690ca6e979625f396d7943e9f9439b8a/dcrec/secp256k1/curve.go#L588-L589), even though they are different doubling formulas, the pattern is still there. 