### PR TITLE
Expose privateInvert in utils

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1476,6 +1476,11 @@ export const utils = {
     return numTo32b(CURVE.n - p);
   },
 
+  privateInvert: (privateKey: PrivKey): Uint8Array => {
+    const p = normalizePrivateKey(privateKey);
+    return numTo32b(invert(p, CURVE.n));
+  },
+
   pointAddScalar: (p: Hex, tweak: Hex, isCompressed?: boolean): Uint8Array => {
     const P = Point.fromHex(p);
     const t = bytesToNumber(ensureBytes(tweak));

--- a/test/index.ts
+++ b/test/index.ts
@@ -477,6 +477,13 @@ describe('secp256k1', () => {
         expect(secp.utils.bytesToHex(secp.utils.privateNegate(a))).toBe(expected);
       }
     });
+    it('privateInvert()', () => {
+      for (const vector of privates.valid.invert) {
+        const { a, expected } = vector;
+        expect(secp.utils.bytesToHex(secp.utils.privateInvert(a))).toBe(expected);
+        expect(secp.utils.bytesToHex(secp.utils.privateInvert(expected))).toBe(a);
+      }
+    });
     it('pointAddScalar()', () => {
       for (const vector of points.valid.pointAddScalar) {
         const { description, P, d, expected } = vector;


### PR DESCRIPTION
This function is needed in building certain higher order protocols on
secp256k1, eg. https://eprint.iacr.org/2020/540.pdf.