### PR TITLE
Add TS types field to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
   ],
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/index.js"
-    },
-    "./index.d.ts": "./lib/index.d.ts"
+    }
   },
   "jest": {
     "testRegex": "/test/.*?\\.ts",


### PR DESCRIPTION
This PR add the "types" field to the export map for [TS usage](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing). This is a similar PR as the recent one to https://github.com/paulmillr/noble-ed25519/pull/66 and https://github.com/paulmillr/noble-hashes/pull/36