### PR TITLE
Example of adding unpkg.com support to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
-  "name": "@noble/secp256k1",
-  "version": "1.7.0",
+  "name": "test-secp256k1",
+  "version": "1.7.1",
   "description": "Fastest JS implementation of secp256k1. Independently audited, high-security, 0-dependency ECDSA & Schnorr signatures",
   "files": [
-    "lib"
+    "lib",
+    "build"
   ],
   "main": "lib/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/index.d.ts",
+  "unpkg": "build/noble-secp256k1.js",
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "build:release": "rollup -c rollup.config.js",
@@ -19,9 +21,9 @@
   },
   "author": "Paul Miller (https://paulmillr.com)",
   "homepage": "https://paulmillr.com/noble/",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/paulmillr/noble-secp256k1.git"
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "license": "MIT",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-secp256k1",
+  "name": "@noble/secp256k1",
   "version": "1.7.1",
   "description": "Fastest JS implementation of secp256k1. Independently audited, high-security, 0-dependency ECDSA & Schnorr signatures",
   "files": [
@@ -21,9 +21,9 @@
   },
   "author": "Paul Miller (https://paulmillr.com)",
   "homepage": "https://paulmillr.com/noble/",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paulmillr/noble-secp256k1.git"
   },
   "license": "MIT",
   "browser": {

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Browser Import Test</title>
+  <script src="https://unpkg.com/test-secp256k1@1.7.1"></script>
+  <!-- <script src="../build/noble-secp256k1.js"></script> -->
+</head>
+<body>
+  <h1>Browser Import Test</h1>
+  <p>Check the console for more info.</p>
+  <script>console.log(window.nobleSecp256k1)</script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -5,12 +5,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Browser Import Test</title>
-  <script src="https://unpkg.com/test-secp256k1@1.7.1"></script>
-  <!-- <script src="../build/noble-secp256k1.js"></script> -->
+  <!-- <script src="https://unpkg.com/@noble/secp256k1@1.7.1"></script> -->
+  <script src="../build/noble-secp256k1.js"></script>
 </head>
 <body>
   <h1>Browser Import Test</h1>
   <p>Check the console for more info.</p>
-  <script>console.log(window.nobleSecp256k1)</script>
+  <script>console.log('nobleSecp256k1:', window.nobleSecp256k1)</script>
 </body>
 </html>


### PR DESCRIPTION
Please see below. The browser-compatible version is located in the build folder, so I added the key `"unpkg": "build/noble-secp256k1.js"`, and also added `"build"` to `"files"`.

I test deployed this configuration, you can see it here:  
https://www.npmjs.com/package/test-secp256k1

It is reachable by unpkg.com here:  
https://unpkg.com/test-secp256k1

(the test package will delete in 24 hours)

I also added an `index.html` in the `test` folder to demonstrate that the import works, both locally and from the CDN. Let me know if you have any questions!