### PR TITLE
feat: add crypto to utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage/
 /lib/**/*.js
 /lib/**/*.ts
 /lib/**/*.d.ts.map
+.idea
+yarn.lock

--- a/index.ts
+++ b/index.ts
@@ -1478,7 +1478,10 @@ export const utils = {
   invert,
   crypto: {
     node: nodeCrypto,
-    web: typeof self === 'object' && 'crypto' in self  && 'subtle' in self.crypto ? self.crypto : undefined,
+    web:
+      typeof self === 'object' && 'crypto' in self && 'subtle' in self.crypto
+        ? self.crypto
+        : undefined,
   },
 
   isValidPrivateKey(privateKey: PrivKey) {


### PR DESCRIPTION
in working with react-native, I found that I would like a higher ability pass a crypto library that this library uses. I am able to do so with other noble libs, like `@noble/hashes`:

```ts
import crypto from 'crypto'; // is actually react-native-quick-crypto
import { crypto as _crypto } from '@noble/hashes/crypto';

_crypto.node = crypto;
_crypto.web = undefined;
```

this PR follows the example in the readme of updating the util:
```ts
import { hmac } = from '@noble/hashes/hmac';
import { sha256 } from '@noble/hashes/sha256';
secp256k1.utils.hmacSha256Sync = (key, ...msgs) => hmac(sha256, key, secp256k1.utils.concatBytes(...msgs))
```

but the way in which you'd do it for crypto is like so:

```ts
import crypto from 'crypto'; // is actually react-native-quick-crypto
import * as secp256k1 from '@noble/secp256k1';

secp256k1.utils.crypto = {
  node: crypto,
  web: undefined
}
```

There should be no change to the experience that folks have currently if they pass nothing.

related https://github.com/paulmillr/noble-secp256k1/issues/80