### PR TITLE
Switches to using webcrypto everywhere.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@rollup/plugin-commonjs": "22.0.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@types/jest": "28.1.1",
-    "@types/node": "17.0.18",
+    "@types/node": "18.11.18",
     "fast-check": "3.0.0",
     "jest": "28.1.0",
     "micro-bmark": "0.2.0",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,3 +1,4 @@
+globalThis.crypto || (globalThis.crypto = require('node:crypto').webcrypto)
 const { run, mark, logMem } = require('micro-bmark');
 const secp = require('..');
 const { join } = require('path');

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,13 +1,17 @@
+import { createHash, webcrypto } from 'crypto';
+// polyfill for running tests in NodeJS v16-v18, must come before import '@noble/secp256k1'
+declare module globalThis { let crypto: webcrypto.Crypto }
+globalThis.crypto || (globalThis.crypto = webcrypto)
 import * as fc from 'fast-check';
 import * as secp from '..';
 import { readFileSync } from 'fs';
-import { createHash } from 'crypto';
 import * as sysPath from 'path';
 import * as ecdsa from './vectors/ecdsa.json';
 import * as ecdh from './vectors/ecdh.json';
 import * as privates from './vectors/privates.json';
 import * as points from './vectors/points.json';
 import * as wp from './vectors/wychenproof.json';
+jest.setTimeout(20000)
 const privatesTxt = readFileSync(sysPath.join(__dirname, 'vectors', 'privates-2.txt'), 'utf-8');
 const schCsv = readFileSync(sysPath.join(__dirname, 'vectors', 'schnorr.csv'), 'utf-8');
 


### PR DESCRIPTION
`globalThis.crypto` is available in all major browsers, deno, and NodeJS 19+. It is also available behind experimental flag in NodeJS 16-18, and exists at `import {webcrypto} from 'node:crypto'`.

Updated tests to polyfill webcrypto so they can run in NodeJS 16+ without experimental flags.

Bumped @types/node to v18 so it has the latest subtlecrypto definitions.