### PR TITLE
Use `node:` specifier for crypto import

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ import * as secp from '@noble/secp256k1';
 })();
 ```
 
-To use the module with [Deno](https://deno.land),
-you will need [import map](https://deno.land/manual/linking_to_external_code/import_maps):
+To use the module with [Deno](https://deno.land):
 
-- `deno run --import-map=imports.json app.ts`
-- app.ts: `import * as secp from "https://deno.land/x/secp256k1/mod.ts";`
-- imports.json: `{"imports": {"crypto": "https://deno.land/std@0.153.0/node/crypto.ts"}}`
+```js
+import * as secp from "https://deno.land/x/secp256k1/mod.ts";
+```
 
 ## API
 

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@
 
 // Uses built-in crypto module from node.js to generate randomness / hmac-sha256.
 // In browser the line is automatically removed during build time: uses crypto.subtle instead.
-import * as nodeCrypto from 'crypto';
+import * as nodeCrypto from 'node:crypto';
 
 // Be friendly to bad ECMAScript parsers by not using bigint literals like 123n
 const _0n = BigInt(0);


### PR DESCRIPTION
Improves Deno support.

So, I see you're overhauling this library in #92, but I figured I'd submit this anyway so you can see the diff.

Importing `node:crypto` is supported in both [Deno](https://deno.land/manual@v1.30.3/node/node_specifiers) and [Node.js](https://nodejs.org/api/esm.html#node-imports) as far back as v14.18.0 (the oldest supported LTS). And it simplifies things for Deno users a lot.

In #92 you could still `require('node:crypto')` to get the same advantages. Although... I think Deno might take the web APIs in that case anyway(?)