### PR TITLE
Corrects type of `sign` and `signAsync`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -217,7 +217,7 @@ let _hmacSync: HmacFnSync;    // Can be redefined by use in utils; built-ins don
 const optS: { lowS?: boolean; extraEntropy?: boolean | Hex; } = { lowS: true }; // opts for sign()
 const optV: { lowS?: boolean } = { lowS: true };        // standard opts for verify()
 type BC = { seed: Bytes, k2sig : (kb: Bytes) => Signature | undefined }; // Bytes+predicate checker
-function prepSig(msgh: Hex, priv: Hex, opts = optS): BC { // prepare for RFC6979 sig generation
+function prepSig(msgh: Hex, priv: PrivKey, opts = optS): BC { // prepare for RFC6979 sig generation
   if (['der', 'recovered', 'canonical'].some(k => k in opts)) // Ban legacy options
     err('sign() legacy options not supported');
   let { lowS } = opts;                                  // generates low-s sigs by default
@@ -313,11 +313,11 @@ function hmacDrbg<T>(asynchronous: boolean) { // HMAC-DRBG async
   }
 }
 // ECDSA signature generation. via secg.org/sec1-v2.pdf 4.1.2 + RFC6979 deterministic k
-async function signAsync(msgh: Hex, priv: Hex, opts = optS): Promise<Signature> {
+async function signAsync(msgh: Hex, priv: PrivKey, opts = optS): Promise<Signature> {
   const { seed, k2sig } = prepSig(msgh, priv, opts);    // Extract arguments for hmac-drbg
   return hmacDrbg<Signature>(true)(seed, k2sig);        // Re-run hmac-drbg until k2sig returns ok
 }
-function sign(msgh: Hex, priv: Hex, opts = optS): Signature {
+function sign(msgh: Hex, priv: PrivKey, opts = optS): Signature {
   const { seed, k2sig } = prepSig(msgh, priv, opts);    // Extract arguments for hmac-drbg
   return hmacDrbg<Signature>(false)(seed, k2sig);       // Re-run hmac-drbg until k2sig returns ok
 }


### PR DESCRIPTION
The only place that `priv` is used in `signAsync` and `sign` is when it is passed to `prepSig`.  The only place `priv` is used in `prepSig` is when it is passed to `toPriv`.  `toPriv` takes a `PrivKey`, so that means `prepSig`, `sign`, and `signAsync` can also take a `PrivKey`.

Functionally, this means that `bigint` is now allowed as a private key.  This will make it so users who are storing private keys in memory as bigints will not have to first convert to hex.

Node: Currently if you naively convert your bigint private key to hex using `0x${privateKey.toString(16)}` this library will throw an error complaining about the hex for the private key being the wrong length.  Arguably this library should accept an odd length hex value for the private key, but in my case just accepting bigints directly would fix the issue and allowing odd length hex strings would require an actual code change rather than just a type change.