### PR TITLE
test: fix filename in test/tsconfig.json

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,6 +8,6 @@
     "preserveConstEnums": true,
     "resolveJsonModule": true
   },
-  "include": ["secp256k1.helpers.mts"],
+  "include": ["secp256k1.helpers.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
The helpers file was renamed in eddf00273f8f8649a7e11b925c6ad7c3e7f5433b but the test tsconfig was left configured with the old filename.

This updates the definition file accordingly.