### PR TITLE
noble-secp256k1 is not handling properly the point at infinity

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,12 +462,10 @@ const utils = {
     randomPrivateKey: () => hashToPrivateKey(etc.randomBytes(fLen + 8)),
     precompute(w = 8, p = G) { p.multiply(3n); w; return p; }, // no-op
 };
-Object.defineProperties(etc, {
-    hmacSha256Sync: {
+Object.defineProperties(etc, { hmacSha256Sync: {
         configurable: false, get() { return _hmacSync; }, set(f) { if (!_hmacSync)
             _hmacSync = f; },
-    }
-});
+    } });
 const W = 8; // Precomputes-related code. W = window size
 const precompute = () => {
     const points = []; // 10x sign(), 2x verify(). To achieve this,

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ class Point {
         this.pz = pz;
     } //3d=less inversions
     static fromAffine(p) {
-        if ((p.x == 0n) && (p.y == 0n))
+        if ((p.x === 0n) && (p.y === 0n))
             return new Point(0n, 1n, 0n);
         else
             return new Point(p.x, p.y, 1n);
@@ -462,10 +462,12 @@ const utils = {
     randomPrivateKey: () => hashToPrivateKey(etc.randomBytes(fLen + 8)),
     precompute(w = 8, p = G) { p.multiply(3n); w; return p; }, // no-op
 };
-Object.defineProperties(etc, { hmacSha256Sync: {
+Object.defineProperties(etc, {
+    hmacSha256Sync: {
         configurable: false, get() { return _hmacSync; }, set(f) { if (!_hmacSync)
             _hmacSync = f; },
-    } });
+    }
+});
 const W = 8; // Precomputes-related code. W = window size
 const precompute = () => {
     const points = []; // 10x sign(), 2x verify(). To achieve this,

--- a/index.js
+++ b/index.js
@@ -26,7 +26,12 @@ class Point {
         this.py = py;
         this.pz = pz;
     } //3d=less inversions
-    static fromAffine(p) { return new Point(p.x, p.y, 1n); }
+    static fromAffine(p) {
+        if ((p.x == 0n) && (p.y == 0n))
+            return new Point(0n, 1n, 0n);
+        else
+            return new Point(p.x, p.y, 1n);
+    }
     static fromHex(hex) {
         hex = toU8(hex); // convert hex string to Uint8Array
         let p = undefined;

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ const P = B256 - 0x1000003d1n;                          // curve's field prime
 const N = B256 - 0x14551231950b75fc4402da1732fc9bebfn;  // curve (group) order
 const Gx = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798n; // base point x
 const Gy = 0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8n; // base point y
-const CURVE = {p: P, n: N, a: 0n, b: 7n, Gx, Gy};       // exported variables incl. a, b
+const CURVE = { p: P, n: N, a: 0n, b: 7n, Gx, Gy };       // exported variables incl. a, b
 const fLen = 32;                                        // field / group byte length
 type Bytes = Uint8Array; type Hex = Bytes | string; type PrivKey = Hex | bigint;
 const crv = (x: bigint) => mod(mod(x * x) * x + CURVE.b); // x³ + ax + b weierstrass formula; a=0
@@ -23,12 +23,12 @@ const isPoint = (p: unknown) => (p instanceof Point ? p : err('Point expected'))
 let Gpows: Point[] | undefined = undefined;             // precomputes for base point G
 interface AffinePoint { x: bigint, y: bigint }          // Point in 2d xy affine coordinates
 class Point {                                           // Point in 3d xyz projective coordinates
-  constructor(readonly px: bigint, readonly py: bigint, readonly pz: bigint) {} //3d=less inversions
+  constructor(readonly px: bigint, readonly py: bigint, readonly pz: bigint) { } //3d=less inversions
   static readonly BASE = new Point(Gx, Gy, 1n);         // Generator / base point
   static readonly ZERO = new Point(0n, 1n, 0n);         // Identity / zero point
-  static fromAffine ( p: AffinePoint ) {
-    if (( p.x == 0n ) && ( p.y == 0n ) ) return new Point (0n , 1n , 0n );
-    else return new Point ( p.x , p.y , 1n ) ;
+  static fromAffine(p: AffinePoint) {
+    if ((p.x === 0n) && (p.y === 0n)) return new Point(0n, 1n, 0n);
+    else return new Point(p.x, p.y, 1n);
   }
   static fromHex(hex: Hex): Point {                     // Convert Uint8Array or hex string to Point
     hex = toU8(hex);                                    // convert hex string to Uint8Array
@@ -147,7 +147,7 @@ const n2h = (num: bigint): string => b2h(n2b(num));     // number to 32b hex
 const concatB = (...arrs: Bytes[]) => {                 // concatenate Uint8Array-s
   const r = u8n(arrs.reduce((sum, a) => sum + au8(a).length, 0)); // create u8a of summed length
   let pad = 0;                                          // walk through each array,
-  arrs.forEach(a => {r.set(a, pad); pad += a.length});  // ensure they have proper type
+  arrs.forEach(a => { r.set(a, pad); pad += a.length });  // ensure they have proper type
   return r;
 };
 const inv = (num: bigint, md = P): bigint => {          // modular inversion
@@ -222,7 +222,7 @@ type HmacFnSync = undefined | ((key: Bytes, ...msgs: Bytes[]) => Bytes);
 let _hmacSync: HmacFnSync;    // Can be redefined by use in utils; built-ins don't provide it
 const optS: { lowS?: boolean; extraEntropy?: boolean | Hex; } = { lowS: true }; // opts for sign()
 const optV: { lowS?: boolean } = { lowS: true };        // standard opts for verify()
-type BC = { seed: Bytes, k2sig : (kb: Bytes) => SignatureWithRecovery | undefined }; // Bytes+predicate checker
+type BC = { seed: Bytes, k2sig: (kb: Bytes) => SignatureWithRecovery | undefined }; // Bytes+predicate checker
 function prepSig(msgh: Hex, priv: PrivKey, opts = optS): BC { // prepare for RFC6979 sig generation
   if (['der', 'recovered', 'canonical'].some(k => k in opts)) // Ban legacy options
     err('sign() legacy options not supported');
@@ -373,7 +373,7 @@ const etc = {                                           // Not placed in utils b
     const c = cr();                                     // async HMAC-SHA256, no sync built-in!
     const s = c && c.subtle;                            // For React Native support, see README.
     if (!s) return err('etc.hmacSha256Async not set');  // Uses webcrypto built-in cryptography.
-    const k = await s.importKey('raw', key, {name:'HMAC',hash:{name:'SHA-256'}}, false, ['sign']);
+    const k = await s.importKey('raw', key, { name: 'HMAC', hash: { name: 'SHA-256' } }, false, ['sign']);
     return u8n(await s.sign('HMAC', k, concatB(...msgs)));
   },
   hmacSha256Sync: _hmacSync,                            // For TypeScript. Actual logic is below
@@ -388,11 +388,13 @@ const utils = {                                         // utilities
   normPrivateKeyToScalar: toPriv,
   isValidPrivateKey: (key: Hex) => { try { return !!toPriv(key); } catch (e) { return false; } },
   randomPrivateKey: (): Bytes => hashToPrivateKey(etc.randomBytes(fLen + 8)), // FIPS 186 B.4.1.
-  precompute(w=8, p: Point = G) { p.multiply(3n); w; return p; }, // no-op
+  precompute(w = 8, p: Point = G) { p.multiply(3n); w; return p; }, // no-op
 };
-Object.defineProperties(etc, { hmacSha256Sync: {        // Allow setting it once, ignore then
-  configurable: false, get() { return _hmacSync; }, set(f) { if (!_hmacSync) _hmacSync = f; },
-} });
+Object.defineProperties(etc, {
+  hmacSha256Sync: {        // Allow setting it once, ignore then
+    configurable: false, get() { return _hmacSync; }, set(f) { if (!_hmacSync) _hmacSync = f; },
+  }
+});
 const W = 8;                                            // Precomputes-related code. W = window size
 const precompute = () => {                              // They give 12x faster getPublicKey(),
   const points: Point[] = [];                           // 10x sign(), 2x verify(). To achieve this,
@@ -407,7 +409,7 @@ const precompute = () => {                              // They give 12x faster 
   return points;                                        // when precomputes are using base point
 }
 const wNAF = (n: bigint): { p: Point; f: Point } => {   // w-ary non-adjacent form (wNAF) method.
-                                                        // Compared to other point mult methods,
+  // Compared to other point mult methods,
   const comp = Gpows || (Gpows = precompute());         // stores 2x less points using subtraction
   const neg = (cnd: boolean, p: Point) => { let n = p.negate(); return cnd ? n : p; } // negate
   let p = I, f = G;                                     // f must be G, or could become I in the end
@@ -431,5 +433,7 @@ const wNAF = (n: bigint): { p: Point; f: Point } => {   // w-ary non-adjacent fo
   }
   return { p, f }                                       // return both real and fake points for JIT
 };        // !! you can disable precomputes by commenting-out call of the wNAF() inside Point#mul()
-export { getPublicKey, sign, signAsync, verify, CURVE,  // Remove the export to easily use in REPL
-  getSharedSecret, etc, utils, Point as ProjectivePoint, Signature } // envs like browser console
+export {
+  getPublicKey, sign, signAsync, verify, CURVE,  // Remove the export to easily use in REPL
+  getSharedSecret, etc, utils, Point as ProjectivePoint, Signature
+} // envs like browser console

--- a/index.ts
+++ b/index.ts
@@ -27,8 +27,8 @@ class Point {                                           // Point in 3d xyz proje
   static readonly BASE = new Point(Gx, Gy, 1n);         // Generator / base point
   static readonly ZERO = new Point(0n, 1n, 0n);         // Identity / zero point
   static fromAffine (p: AffinePoint) {
-    if ((p.x === 0n) && (p.y === 0n)) return new Point (0n , 1n , 0n );
-    else return new Point ( p.x , p.y , 1n ) ;
+    if ((p.x === 0n) && (p.y === 0n)) return Point.ZERO;
+    else return new Point(p.x, p.y, 1n) ;
   }
   static fromHex(hex: Hex): Point {                     // Convert Uint8Array or hex string to Point
     hex = toU8(hex);                                    // convert hex string to Uint8Array

--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,10 @@ class Point {                                           // Point in 3d xyz proje
   constructor(readonly px: bigint, readonly py: bigint, readonly pz: bigint) {} //3d=less inversions
   static readonly BASE = new Point(Gx, Gy, 1n);         // Generator / base point
   static readonly ZERO = new Point(0n, 1n, 0n);         // Identity / zero point
-  static fromAffine(p: AffinePoint) { return new Point(p.x, p.y, 1n); }
+  static fromAffine ( p: AffinePoint ) {
+    if (( p.x == 0n ) && ( p.y == 0n ) ) return new Point (0n , 1n , 0n );
+    else return new Point ( p.x , p.y , 1n ) ;
+  }
   static fromHex(hex: Hex): Point {                     // Convert Uint8Array or hex string to Point
     hex = toU8(hex);                                    // convert hex string to Uint8Array
     let p: Point | undefined = undefined;

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ const P = B256 - 0x1000003d1n;                          // curve's field prime
 const N = B256 - 0x14551231950b75fc4402da1732fc9bebfn;  // curve (group) order
 const Gx = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798n; // base point x
 const Gy = 0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8n; // base point y
-const CURVE = { p: P, n: N, a: 0n, b: 7n, Gx, Gy };       // exported variables incl. a, b
+const CURVE = {p: P, n: N, a: 0n, b: 7n, Gx, Gy};       // exported variables incl. a, b
 const fLen = 32;                                        // field / group byte length
 type Bytes = Uint8Array; type Hex = Bytes | string; type PrivKey = Hex | bigint;
 const crv = (x: bigint) => mod(mod(x * x) * x + CURVE.b); // x³ + ax + b weierstrass formula; a=0
@@ -23,12 +23,12 @@ const isPoint = (p: unknown) => (p instanceof Point ? p : err('Point expected'))
 let Gpows: Point[] | undefined = undefined;             // precomputes for base point G
 interface AffinePoint { x: bigint, y: bigint }          // Point in 2d xy affine coordinates
 class Point {                                           // Point in 3d xyz projective coordinates
-  constructor(readonly px: bigint, readonly py: bigint, readonly pz: bigint) { } //3d=less inversions
+  constructor(readonly px: bigint, readonly py: bigint, readonly pz: bigint) {} //3d=less inversions
   static readonly BASE = new Point(Gx, Gy, 1n);         // Generator / base point
   static readonly ZERO = new Point(0n, 1n, 0n);         // Identity / zero point
-  static fromAffine(p: AffinePoint) {
-    if ((p.x === 0n) && (p.y === 0n)) return new Point(0n, 1n, 0n);
-    else return new Point(p.x, p.y, 1n);
+  static fromAffine (p: AffinePoint) {
+    if ((p.x === 0n) && (p.y === 0n)) return new Point (0n , 1n , 0n );
+    else return new Point ( p.x , p.y , 1n ) ;
   }
   static fromHex(hex: Hex): Point {                     // Convert Uint8Array or hex string to Point
     hex = toU8(hex);                                    // convert hex string to Uint8Array
@@ -147,7 +147,7 @@ const n2h = (num: bigint): string => b2h(n2b(num));     // number to 32b hex
 const concatB = (...arrs: Bytes[]) => {                 // concatenate Uint8Array-s
   const r = u8n(arrs.reduce((sum, a) => sum + au8(a).length, 0)); // create u8a of summed length
   let pad = 0;                                          // walk through each array,
-  arrs.forEach(a => { r.set(a, pad); pad += a.length });  // ensure they have proper type
+  arrs.forEach(a => {r.set(a, pad); pad += a.length});  // ensure they have proper type
   return r;
 };
 const inv = (num: bigint, md = P): bigint => {          // modular inversion
@@ -222,7 +222,7 @@ type HmacFnSync = undefined | ((key: Bytes, ...msgs: Bytes[]) => Bytes);
 let _hmacSync: HmacFnSync;    // Can be redefined by use in utils; built-ins don't provide it
 const optS: { lowS?: boolean; extraEntropy?: boolean | Hex; } = { lowS: true }; // opts for sign()
 const optV: { lowS?: boolean } = { lowS: true };        // standard opts for verify()
-type BC = { seed: Bytes, k2sig: (kb: Bytes) => SignatureWithRecovery | undefined }; // Bytes+predicate checker
+type BC = { seed: Bytes, k2sig : (kb: Bytes) => SignatureWithRecovery | undefined }; // Bytes+predicate checker
 function prepSig(msgh: Hex, priv: PrivKey, opts = optS): BC { // prepare for RFC6979 sig generation
   if (['der', 'recovered', 'canonical'].some(k => k in opts)) // Ban legacy options
     err('sign() legacy options not supported');
@@ -373,7 +373,7 @@ const etc = {                                           // Not placed in utils b
     const c = cr();                                     // async HMAC-SHA256, no sync built-in!
     const s = c && c.subtle;                            // For React Native support, see README.
     if (!s) return err('etc.hmacSha256Async not set');  // Uses webcrypto built-in cryptography.
-    const k = await s.importKey('raw', key, { name: 'HMAC', hash: { name: 'SHA-256' } }, false, ['sign']);
+    const k = await s.importKey('raw', key, {name:'HMAC',hash:{name:'SHA-256'}}, false, ['sign']);
     return u8n(await s.sign('HMAC', k, concatB(...msgs)));
   },
   hmacSha256Sync: _hmacSync,                            // For TypeScript. Actual logic is below
@@ -388,13 +388,11 @@ const utils = {                                         // utilities
   normPrivateKeyToScalar: toPriv,
   isValidPrivateKey: (key: Hex) => { try { return !!toPriv(key); } catch (e) { return false; } },
   randomPrivateKey: (): Bytes => hashToPrivateKey(etc.randomBytes(fLen + 8)), // FIPS 186 B.4.1.
-  precompute(w = 8, p: Point = G) { p.multiply(3n); w; return p; }, // no-op
+  precompute(w=8, p: Point = G) { p.multiply(3n); w; return p; }, // no-op
 };
-Object.defineProperties(etc, {
-  hmacSha256Sync: {        // Allow setting it once, ignore then
-    configurable: false, get() { return _hmacSync; }, set(f) { if (!_hmacSync) _hmacSync = f; },
-  }
-});
+Object.defineProperties(etc, { hmacSha256Sync: {        // Allow setting it once, ignore then
+  configurable: false, get() { return _hmacSync; }, set(f) { if (!_hmacSync) _hmacSync = f; },
+} });
 const W = 8;                                            // Precomputes-related code. W = window size
 const precompute = () => {                              // They give 12x faster getPublicKey(),
   const points: Point[] = [];                           // 10x sign(), 2x verify(). To achieve this,
@@ -409,7 +407,7 @@ const precompute = () => {                              // They give 12x faster 
   return points;                                        // when precomputes are using base point
 }
 const wNAF = (n: bigint): { p: Point; f: Point } => {   // w-ary non-adjacent form (wNAF) method.
-  // Compared to other point mult methods,
+                                                        // Compared to other point mult methods,
   const comp = Gpows || (Gpows = precompute());         // stores 2x less points using subtraction
   const neg = (cnd: boolean, p: Point) => { let n = p.negate(); return cnd ? n : p; } // negate
   let p = I, f = G;                                     // f must be G, or could become I in the end
@@ -433,7 +431,5 @@ const wNAF = (n: bigint): { p: Point; f: Point } => {   // w-ary non-adjacent fo
   }
   return { p, f }                                       // return both real and fake points for JIT
 };        // !! you can disable precomputes by commenting-out call of the wNAF() inside Point#mul()
-export {
-  getPublicKey, sign, signAsync, verify, CURVE,  // Remove the export to easily use in REPL
-  getSharedSecret, etc, utils, Point as ProjectivePoint, Signature
-} // envs like browser console
+export { getPublicKey, sign, signAsync, verify, CURVE,  // Remove the export to easily use in REPL
+  getSharedSecret, etc, utils, Point as ProjectivePoint, Signature } // envs like browser console

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@noble/hashes": "1.3.0",
+        "@noble/hashes": "1.3.2",
         "fast-check": "3.0.0",
         "micro-bmark": "0.3.0",
         "micro-should": "0.4.0",
@@ -20,16 +20,16 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/fast-check": {
       "version": "3.0.0",


### PR DESCRIPTION
the `toAffine` method encodes the point at infinity O in affine coordinates as (0, 0):
```typescript
if ( this.equals(I)) return { x: 0n , y: 0n }; // fast - path for zero point
```

The code of fromAffine importing affine to projective is the following:
```typescript
static fromAffine (p: AffinePoint) {
  return new Point (p.x , p.y , 1n) ;
}
```

As we can see, `fromAffine` does not check for (0, 0) to properly import O. This means that silent errors in the computation will occur when exporting and then importing O, which can happen with valid operations (such as (l − 1) · P + P where P is a point of order l).

A simple way to fix it: 
```typescript
static fromAffine (p: AffinePoint) {
  if ((p.x === 0n) && (p.y === 0n)) return new Point (0n , 1n , 0n);
  else return new Point (p.x , p.y , 1n) ;
}
```

Solved with @LeJamon