### PR TITLE
feature detect to avoid self.crypto if subtle isn't available

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -222,7 +222,7 @@ const bits2int_modN = (bytes: Uint8Array): bigint => {  // int2octets can't be u
 const i2o = (num: bigint): Bytes => n2b(num);           // int to octets
 declare const globalThis: Record<string, any> | undefined; // Typescript symbol present in browsers
 const cr = () => // We support: 1) browsers 2) node.js 19+ 3) deno, other envs with crypto
-  typeof globalThis === 'object' && 'crypto' in globalThis ? globalThis.crypto : undefined;
+  typeof globalThis === 'object' && 'crypto' in globalThis && 'subtle' in globalThis.crypto ? globalThis.crypto : undefined;
 type HmacFnSync = undefined | ((key: Bytes, ...msgs: Bytes[]) => Bytes);
 let _hmacSync: HmacFnSync;    // Can be redefined by use in utils; built-ins don't provide it
 const optS: { lowS?: boolean; extraEntropy?: boolean | Hex; } = { lowS: true }; // opts for sign()


### PR DESCRIPTION
In context of React Native environment, some polyfill exists like `react-native-get-random-values` that implements `global.crypto.getRandomValues` function but do not provide a `crypto.subtle` implementation. ( example of lib that recommend this polyfill https://docs.ethers.org/v5/cookbook/react-native/#cookbook-reactnative )

Since `@noble/secp256k1` requires an implementation of crypto.subtle to be able to do things like `crypto.web.subtle.digest('SHA-256', concatBytes(...messages))` it is necessary for the feature detection to consider the extra case where `crypto.web.subtle` might not be available.


Without this fix, you get `TypeError: Cannot read property 'digest' of undefined` as soon as you start using `.util.sha256` function