### PR TITLE
test: label tests dir as having sideEffects=true

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": true
+}


### PR DESCRIPTION
Mirror of:
* https://github.com/paulmillr/noble-ed25519/pull/105

This package is labelled as `sideEffects=false`:
https://github.com/paulmillr/noble-secp256k1/blob/3aa804ba71c478a75013cd4fda4faa7e7a1af58e/package.json#L10-L14

That shouldn't apply to tests, because of:
1. This bare import: https://github.com/paulmillr/noble-secp256k1/blob/3aa804ba71c478a75013cd4fda4faa7e7a1af58e/test/secp256k1.webcrypto.test.js#L5
2. This setup (which is required): https://github.com/paulmillr/noble-secp256k1/blob/3aa804ba71c478a75013cd4fda4faa7e7a1af58e/test/secp256k1.helpers.js#L6

Adding `sideEffects=true` to the test dir makes tests suitable for running in bundled mode

To test:
* [x] `npm test`
* [ ] CI 
* [x] `npx @exodus/test` (Node.js)
* [x] `npx @exodus/test --engine jsc:bundle` (JSC)
     Requires `jsc` available in PATH
* [x] `npx @exodus/test --engine hermes:bundle` (Hermes) 
     Requires `hermes` available in PATH or https://npmjs.com/hermes-engine-cli installed with `@exodus/test`:
   `npm add @exodus/test hermes-engine-cli`

Refs: https://github.com/paulmillr/noble-curves/pull/166