### PR TITLE
test: clean up test:webcrypto logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:mingz": "npm run --silent build:min | gzip -c8",
     "build:release": "npm run --silent build:min > test/build/noble-secp256k1.min.js; npm run --silent build:mingz > test/build/noble-secp256k1.min.js.gz",
     "test": "node test/index.js",
-    "test:webcrypto": "node test/secp256k1.webcrypto.test.js",
+    "test:webcrypto": "node test/index.webcrypto.js",
     "bench": "node test/benchmark.js",
     "loc": "echo \"`npm run --silent build:min | wc -c` symbols `wc -l < index.ts` LOC, `npm run --silent build:mingz | wc -c`B gzipped\""
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,9 @@
 import { should } from 'micro-should';
-import * as t1 from './basic.test.js';
-import * as t2 from './secp256k1.test.js';
+import './basic.test.js';
+import './secp256k1.test.js';
+
+if (!globalThis.crypto) {
+  console.error('global crypto not found (old Node.js?), perhaps you meant to run test:webcrypto');
+}
 
 should.run();

--- a/test/index.webcrypto.js
+++ b/test/index.webcrypto.js
@@ -1,0 +1,9 @@
+import { should } from 'micro-should';
+import './basic.test.js';
+import './secp256k1.test.js';
+
+// A copy of index.js with polyfilled globalThis.crypto to run on Node.js 18
+import { webcrypto } from 'node:crypto';
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+should.run();

--- a/test/secp256k1.webcrypto.test.js
+++ b/test/secp256k1.webcrypto.test.js
@@ -1,9 +1,0 @@
-import { webcrypto } from 'node:crypto';
-// @ts-ignore
-if (!globalThis.crypto) globalThis.crypto = webcrypto;
-
-import './secp256k1.test.js';
-
-// Force ESM import to execute
-import { should } from 'micro-should';
-should.run();


### PR DESCRIPTION
Previously: #105

1. `test:webcrypto` now includes `basic.test`, not just `secp256k1.test`
2. `test:webcrypto` entry is now `test/index.webcrypto.js`, as it's a runner, not it's own test
3. Cleaned up unused variables in `test/index.js` and added a note for anyone who runs `test` on old Node.js versions (as this package has a separate test script for those environments)
4. The webcrypto test code made it seem like `globalThis.crypto = webcrypto;` was being executed before `import './secp256k1.test.js';`, which is not true -- imports are hoisted and always executed first.
    This only works because `cr()` is dynamic, so I just moved that code down to make it more obvious.

Now `test/index.js` and `test/index.webcrypto.js` align with each other
